### PR TITLE
docs: project documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There is no history. No accounts. No scrolling back. Just the current line — l
 - Press `Enter` to take the floor and start typing
 - Only one person types at a time — others see your text live
 - Each user gets a unique color and font (their "voice")
-- Text fades after a set time and character limit *(planned — not yet implemented)*
+- Text fades over time — each character disappears after a timeout or when the rolling window fills
 
 ---
 
@@ -103,4 +103,3 @@ Tracked in [GitHub Issues](https://github.com/vndly/theonelinechat/issues). Key 
 - [v.1 UX spec](https://github.com/vndly/theonelinechat/issues/2)
 - [Room creation](https://github.com/vndly/theonelinechat/issues/6)
 - [User identity — color and font](https://github.com/vndly/theonelinechat/issues/5)
-- [Text fading](https://github.com/vndly/theonelinechat/issues/9)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There is no history. No accounts. No scrolling back. Just the current line — l
 - Press `Enter` to take the floor and start typing
 - Only one person types at a time — others see your text live
 - Each user gets a unique color and font (their "voice")
-- Text fades after a set time and character limit
+- Text fades after a set time and character limit *(planned — not yet implemented)*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,106 @@
-# The One Line Chat
+# The One Line Chat · 1lc
 
-[https://theonelinechat.web.app](https://theonelinechat.web.app)
+> A keyboard-first, ephemeral chat that transposes spoken conversation into text.
+
+**Live:** [theonelinechat.web.app](https://theonelinechat.web.app)
+
+---
+
+## What is 1lc?
+
+1lc is a minimal chat tool built around one constraint: **only one line of text exists at a time.**
+
+There is no history. No accounts. No scrolling back. Just the current line — like words in a conversation that dissolve as they're spoken.
+
+**Core principles:**
+- Everything is keyboard-driven — no mouse required
+- A room can be created and shared in seconds
+- Only the current line being typed is ever visible
+- Text fades over time, mirroring how spoken words vanish
+- No conversation is ever stored
+- Features serve the chat only — no analytics, no side panels
+
+---
+
+## How it works
+
+### Creating a room
+1. Visit the homepage
+2. Press `Enter` — a room is created instantly, its name copied to your clipboard
+3. Share the name (e.g. `flying-ancient-mustard`) with whoever you want to chat with
+
+### Joining a room
+- Navigate directly to `theonelinechat.web.app/flying-ancient-mustard`, or
+- Type the room name on the homepage and press `Enter`
+
+### In the room
+- Press `Enter` to take the floor and start typing
+- Only one person types at a time — others see your text live
+- Each user gets a unique color and font (their "voice")
+- Text fades after a set time and character limit
+
+---
+
+## Tech stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | Vanilla HTML / CSS / JavaScript (no framework) |
+| Realtime sync | Firebase Realtime Database |
+| Hosting | Firebase Hosting |
+| Color generation | OKLCH perceptual color space |
+| Tests | Node.js built-in test runner |
+
+No build step. No bundler. The `public/` folder is served as-is.
+
+---
+
+## Project structure
+
+```
+public/
+  index.html    — single page, minimal markup
+  logic.js      — routing, room/homepage logic, UI state
+  firebase.js   — Firebase Realtime Database interface
+  utils.js      — room ID generation, color math (OKLCH)
+  style.css     — layout and visual styling
+test/
+  utils.test.js — unit tests for utils
+docs/
+  architecture.md        — system design overview
+  contributing.md        — how to contribute
+  decisions/             — Architecture Decision Records (ADRs)
+```
+
+---
+
+## Running locally
+
+No install needed for the frontend — just open `public/index.html` in a browser, or use any static server:
+
+```bash
+npx serve public
+```
+
+To run against a real Firebase instance, you'll need Firebase credentials. See [docs/contributing.md](docs/contributing.md).
+
+**Tests:**
+```bash
+npm test
+```
+
+---
+
+## Documentation
+
+- [Architecture](docs/architecture.md) — how the system is structured and why
+- [Contributing](docs/contributing.md) — setup, conventions, PR process
+- [Decisions](docs/decisions/) — Architecture Decision Records
+
+## Open issues & roadmap
+
+Tracked in [GitHub Issues](https://github.com/vndly/theonelinechat/issues). Key open threads:
+- [v.1 UX spec](https://github.com/vndly/theonelinechat/issues/2)
+- [Room creation](https://github.com/vndly/theonelinechat/issues/6)
+- [User identity — color and font](https://github.com/vndly/theonelinechat/issues/5)
+- [Text fading](https://github.com/vndly/theonelinechat/issues/9)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+# Architecture
+
+## Overview
+
+1lc is a single-page web application with no backend server. All real-time state is managed through Firebase Realtime Database. The frontend is plain HTML, CSS, and JavaScript — no framework, no bundler.
+
+```
+Browser (user A)                Browser (user B)
+     |                               |
+  logic.js                        logic.js
+     |                               |
+  firebase.js ──── Firebase RTDB ── firebase.js
+                   (rooms/{id})
+```
+
+---
+
+## Frontend
+
+**Entry point:** `public/index.html`  
+A single HTML file with minimal markup: a `<textarea>` for input, a hint line, a notification bar, and an overlay for loading state.
+
+**`logic.js`** — main application logic  
+Handles two modes depending on the URL path:
+- **Homepage mode** (`/`): listens for `Enter` to create or join a room
+- **Room mode** (`/:roomId`): registers the user, subscribes to Firebase, manages the floor mechanic
+
+**`firebase.js`** — database interface  
+Thin wrapper over the Firebase SDK. Exports:
+- `setRoom(roomId)` — sets the active room reference
+- `registerUser(roomId, uid, font, color)` — writes user identity into `rooms/{id}/users/{uid}`
+- `getTakenFonts(roomId, uid)` — reads fonts already assigned to other users
+- `listenChat(callback)` — subscribes to room state changes
+- `updateChat({text, color, font, activeUser})` — writes the current line to the room node
+
+**`utils.js`** — pure utility functions  
+- Room ID generation: two adjectives + one noun (e.g. `flying-ancient-mustard`)
+- OKLCH color generation: produces perceptually vivid, contrast-safe colors against the background using binary search over the lightness axis
+- Contrast ratio / luminance helpers (WCAG-compliant)
+
+---
+
+## Data model (Firebase Realtime Database)
+
+```
+rooms/
+  {roomId}/
+    text: string          — current line being typed
+    color: string         — hex color of the active user
+    font: string          — font-family of the active user
+    activeUser: string    — uid of whoever holds the floor
+    users/
+      {uid}/
+        font: string
+        color: string
+```
+
+Rooms are not explicitly deleted — they expire naturally (Firebase TTL or inactivity). No message history is ever written.
+
+---
+
+## User identity
+
+Users are anonymous. Identity is stored in `localStorage`:
+- `uid` — random alphanumeric string, generated once per browser
+- `font` — assigned from a fixed pool of 5 fonts; avoids collisions with other room participants
+- `color` — generated via OKLCH to be visually distinct and contrast-safe against the room background
+
+---
+
+## The floor mechanic
+
+Only one user types at a time. The active typist is tracked via `activeUser` in the room node:
+- Pressing `Enter` claims the floor and clears the line
+- Other users see the text live but their input is disabled
+- First keystroke also claims the floor if it's unclaimed
+
+---
+
+## Hosting & deployment
+
+Hosted on Firebase Hosting. The `public/` directory is served statically with a catch-all rewrite to `index.html` (enabling direct room URL navigation).
+
+```json
+"rewrites": [{ "source": "**", "destination": "/index.html" }]
+```
+
+Deploy: `firebase deploy`
+
+---
+
+## Testing
+
+Unit tests live in `test/utils.test.js` and use the Node.js built-in test runner (`node --test`). They cover the pure utility functions in `utils.js` — color math, room ID generation, sanitisation.
+
+No integration or end-to-end tests yet.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,8 +17,8 @@ Browser (user A)                Browser (user B)
 
 ## Frontend
 
-**Entry point:** `public/index.html`  
-A single HTML file with minimal markup: a `<textarea>` for input, a hint line, a notification bar, and an overlay for loading state.
+**Entry point:** `public/index.html`
+A single HTML file with minimal markup: a `<textarea>` (off-screen in room mode, used only for keyboard capture), a `#display` div (visible text in room mode), a hint line, a notification bar, and an overlay for loading state.
 
 **`logic.js`** — main application logic  
 Handles two modes depending on the URL path:
@@ -31,7 +31,7 @@ Thin wrapper over the Firebase SDK. Exports:
 - `registerUser(roomId, uid, font, color)` — writes user identity into `rooms/{id}/users/{uid}`
 - `getTakenFonts(roomId, uid)` — reads fonts already assigned to other users
 - `listenChat(callback)` — subscribes to room state changes
-- `updateChat({text, color, font, activeUser})` — writes the current line to the room node
+- `updateChat({text, color, font, activeUser, claimedAt})` — writes the current line to the room node
 
 **`utils.js`** — pure utility functions  
 - Room ID generation: two adjectives + one noun (e.g. `flying-ancient-mustard`)
@@ -45,17 +45,18 @@ Thin wrapper over the Firebase SDK. Exports:
 ```
 rooms/
   {roomId}/
-    text: string          — current line being typed
+    text: string          — current line being typed (faded chars removed)
     color: string         — hex color of the active user
     font: string          — font-family of the active user
     activeUser: string    — uid of whoever holds the floor
+    claimedAt: number     — Lamport timestamp of the current floor claim
     users/
       {uid}/
         font: string
         color: string
 ```
 
-Rooms are not explicitly deleted — they expire naturally (Firebase TTL or inactivity). No message history is ever written.
+Rooms are not explicitly deleted — they require a manual cleanup mechanism (Firebase Realtime Database has no built-in TTL). No message history is ever written.
 
 ---
 
@@ -74,6 +75,33 @@ Only one user types at a time. The active typist is tracked via `activeUser` in 
 - Pressing `Enter` claims the floor and clears the line
 - Other users see the text live but their input is disabled
 - First keystroke also claims the floor if it's unclaimed
+
+Floor claims include a `claimedAt` Lamport timestamp (`Math.max(Date.now(), lastSeenClaimedAt + 1)`) to ensure monotonicity. Incoming broadcasts with a lower `claimedAt` than the last seen value are discarded as stale, preventing race conditions when two users claim the floor near-simultaneously.
+
+---
+
+## Text fading
+
+Each character typed by the floor holder is tracked individually in a `chars` array with its insertion timestamp. Two independent triggers cause a character to fade:
+
+1. **Time-based:** a character that has been visible for `FADE_TIMEOUT_MS` (default: 10 seconds) starts fading
+2. **Rolling window:** when the number of active (non-fading) characters reaches `FADE_CHAR_THRESHOLD` (default: 200), the oldest active character is immediately faded
+
+Fading is a CSS animation (`char-fade`, 0.6s ease-out). After the animation completes, the character is removed from `chars` but its DOM `<span>` is kept as an invisible ghost to avoid layout shifts while other chars are still visible. The display and font size reset only once all characters have faded.
+
+**Spectator sync:** spectators receive the text string (faded chars already stripped) via Firebase. `renderStaticDisplay()` diffs the incoming string against the previously rendered state to mirror fading gracefully — avoiding full re-renders on every keystroke.
+
+---
+
+## Dynamic font size
+
+The text display starts at `FONT_SIZE_DEFAULT` (10em). After every character addition, removal, or window resize, `adjustFontSize()` runs inside a `requestAnimationFrame` callback:
+
+1. Measure `displayElement.scrollHeight` vs `window.innerHeight`
+2. If the content overflows, scale down: `newSize = currentSize × (windowHeight / contentHeight)`
+3. Apply the new size — floored at `FONT_SIZE_MIN` (1em)
+
+The font size only ever shrinks while text is present. It resets to the default when the display is fully cleared (all chars faded or `Enter` pressed). This applies to both the floor holder (character-level tracking) and spectators (on each Firebase update).
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,77 @@
+# Contributing
+
+## Prerequisites
+
+- A modern browser (for local testing)
+- Node.js (for running tests)
+- Firebase CLI (for deployment only): `npm install -g firebase-tools`
+
+---
+
+## Local development
+
+No build step required. The `public/` folder is served as-is.
+
+**Quickest way:**
+```bash
+npx serve public
+```
+
+Then open [http://localhost:3000](http://localhost:3000).
+
+> Note: some features (room creation, real-time sync) require a live Firebase connection. For local development against the real Firebase instance, you'll need to be added to the project — ask a maintainer.
+
+---
+
+## Running tests
+
+```bash
+npm test
+```
+
+Uses the Node.js built-in test runner. Tests live in `test/`.
+
+---
+
+## Branch conventions
+
+| Prefix | Use for |
+|--------|---------|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `refactor/` | Code changes with no behaviour change |
+| `test/` | Adding or updating tests |
+
+Example: `feat/room-background-color`
+
+---
+
+## Pull requests
+
+- Keep PRs focused — one concern per PR
+- Reference the related issue in the PR description (e.g. `Closes #6`)
+- PRs to `main` require at least one review
+- Avoid committing directly to `main`
+
+---
+
+## Deployment
+
+Deployment is manual and restricted to maintainers:
+
+```bash
+firebase deploy
+```
+
+This deploys both hosting (`public/`) and database rules (`database.rules.json`).
+
+---
+
+## Code style
+
+- Vanilla JS — no framework, no TypeScript
+- No build tools or bundlers
+- Prefer small, focused modules
+- Pure functions go in `utils.js`; Firebase calls go in `firebase.js`; UI/routing logic goes in `logic.js`
+- Keep `index.html` minimal — no logic in markup

--- a/docs/decisions/001-firebase-realtime-database.md
+++ b/docs/decisions/001-firebase-realtime-database.md
@@ -1,0 +1,32 @@
+# ADR 001 — Firebase Realtime Database for room state
+
+**Date:** 2026-03-16  
+**Status:** Accepted
+
+---
+
+## Context
+
+1lc requires real-time synchronisation of a single shared text line between up to 5 users in a room. The requirements are:
+- Sub-second latency for live text updates
+- No persistent storage of conversation history
+- No backend server to maintain
+- Simple data model (one active line per room)
+
+## Decision
+
+Use **Firebase Realtime Database** for all room state.
+
+## Rationale
+
+- **No server required:** Firebase handles the WebSocket infrastructure, eliminating the need to run and maintain a backend
+- **Simple data model fit:** the room state is a flat object (`text`, `color`, `font`, `activeUser`) — a perfect match for RTDB's JSON tree
+- **Real-time by default:** `onValue` listeners push updates to all clients instantly with no polling
+- **Free tier sufficient:** at current scale, the Spark plan covers all usage
+
+## Consequences
+
+- The project is coupled to Firebase. Migrating away would require replacing `firebase.js` and the data model
+- Firebase Realtime Database is a proprietary service — no self-hosting option
+- All clients connect directly to the database; there is no server-side validation layer beyond database rules
+- Room data is not explicitly deleted — relies on Firebase TTL or manual cleanup

--- a/docs/decisions/001-firebase-realtime-database.md
+++ b/docs/decisions/001-firebase-realtime-database.md
@@ -29,4 +29,4 @@ Use **Firebase Realtime Database** for all room state.
 - The project is coupled to Firebase. Migrating away would require replacing `firebase.js` and the data model
 - Firebase Realtime Database is a proprietary service — no self-hosting option
 - All clients connect directly to the database; there is no server-side validation layer beyond database rules
-- Room data is not explicitly deleted — relies on Firebase TTL or manual cleanup
+- Room data is not explicitly deleted — requires a manual cleanup mechanism (Firebase Realtime Database has no built-in TTL)

--- a/docs/decisions/002-no-framework-no-bundler.md
+++ b/docs/decisions/002-no-framework-no-bundler.md
@@ -1,0 +1,28 @@
+# ADR 002 — No framework, no bundler
+
+**Date:** 2026-03-16  
+**Status:** Accepted
+
+---
+
+## Context
+
+The frontend needs to be simple, fast to load, and easy to contribute to. The application is a single page with minimal DOM interaction — a textarea, a hint line, a notification, and an overlay.
+
+## Decision
+
+Use **vanilla HTML, CSS, and JavaScript** with no framework (React, Vue, Svelte, etc.) and no bundler (Webpack, Vite, etc.).
+
+## Rationale
+
+- **Simplicity matches scope:** the UI is extremely minimal — one input, a few state classes. A framework would add more complexity than it removes
+- **Zero build step:** `public/` is served directly. No compilation, no node_modules in the deploy artefact
+- **Fast load:** no framework runtime to download; the JS is small and loads instantly
+- **Low barrier to contribution:** anyone familiar with the web platform can read and modify the code without learning a framework
+
+## Consequences
+
+- No component model — HTML structure lives in `index.html`, styles in `style.css`, logic in `logic.js`
+- No type safety — plain JS means no compile-time errors
+- If the UI grows significantly in complexity, this decision should be revisited
+- Firebase SDK is loaded from a CDN URL (`gstatic.com`) using ES module imports — no npm install required for the frontend

--- a/docs/decisions/003-oklch-color-generation.md
+++ b/docs/decisions/003-oklch-color-generation.md
@@ -1,0 +1,30 @@
+# ADR 003 — OKLCH for user color generation
+
+**Date:** 2026-03-16  
+**Status:** Accepted
+
+---
+
+## Context
+
+Each user in a room needs a distinct, readable color that serves as their "voice" — visually distinguishing their text from others. Colors must:
+- Be visually vivid and varied (not all pale or all dark)
+- Meet WCAG contrast requirements against the room background
+- Be generated client-side without a server
+
+## Decision
+
+Generate user colors in the **OKLCH perceptual color space**, then binary-search for the lightness value that hits the required WCAG contrast ratio against the current background.
+
+## Rationale
+
+- **Perceptual uniformity:** in OKLCH, equal chroma values look equally vivid across all hues (unlike HSL, where yellow and blue at the same saturation look very different in practice)
+- **Contrast guarantee:** binary search over the lightness axis reliably finds a color that meets the target contrast ratio (WCAG AA Large: 3:1)
+- **No server needed:** entirely client-side math — no API call, no color palette to maintain
+- **Flexible against any background:** the algorithm adapts to whatever background color the room uses
+
+## Consequences
+
+- The color math (`oklchToHex`, `findOKLCHLightness`) is non-trivial and lives in `utils.js` — it is well-commented and covered by tests
+- Near-gamut-boundary colors can cause rare non-monotonicity in the lightness→luminance curve; handled by a retry loop (up to 10 attempts) with an achromatic fallback
+- Colors are generated once per user session and stored in `localStorage` — they persist across page reloads

--- a/docs/decisions/004-textarea-display-split.md
+++ b/docs/decisions/004-textarea-display-split.md
@@ -1,0 +1,28 @@
+# ADR 004 — Separate textarea (input capture) from display div
+
+**Date:** 2026-03-16
+**Status:** Accepted
+
+---
+
+## Context
+
+Text fading requires rendering each character as an individual DOM element so it can be independently animated. A plain `<textarea>` exposes its content as a single string — there is no way to attach animations to individual characters inside it.
+
+At the same time, the `<textarea>` provides reliable, cross-browser keyboard input handling (including mobile keyboards, IME composition, and accessibility).
+
+## Decision
+
+In room mode, move the `<textarea>` off-screen (`position: fixed; top: -9999px`) and use a `<div id="display">` for all visible text. Each character is a `<span class="char">` inside the display div. The textarea remains focused so it continues to capture keyboard input normally.
+
+## Rationale
+
+- **Per-character animation:** individual `<span>` elements can be faded with CSS independently
+- **Preserves input reliability:** the browser's native text input handling (keyboard events, IME, mobile) stays intact via the textarea
+- **No virtual keyboard replacement:** building a custom keyboard handler would be fragile and inaccessible; keeping the textarea avoids this entirely
+
+## Consequences
+
+- Two sources of truth must be kept in sync: the `chars[]` array (floor holder) and the textarea value (`syncTextareaToChars()` is called after every mutation)
+- The textarea's visual state (value, font, color) is never shown to the user in room mode — only the display div is visible
+- Spectators render directly into `#display` without a textarea mirror, since they never hold the floor

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -7,6 +7,7 @@ Short documents capturing key architectural decisions — the context that led t
 | [001](001-firebase-realtime-database.md) | Firebase Realtime Database for room state | Accepted |
 | [002](002-no-framework-no-bundler.md) | No framework, no bundler | Accepted |
 | [003](003-oklch-color-generation.md) | OKLCH for user color generation | Accepted |
+| [004](004-textarea-display-split.md) | Separate textarea (input capture) from display div | Accepted |
 
 ---
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,13 @@
+# Architecture Decision Records
+
+Short documents capturing key architectural decisions — the context that led to them, the decision itself, and their consequences.
+
+| # | Decision | Status |
+|---|----------|--------|
+| [001](001-firebase-realtime-database.md) | Firebase Realtime Database for room state | Accepted |
+| [002](002-no-framework-no-bundler.md) | No framework, no bundler | Accepted |
+| [003](003-oklch-color-generation.md) | OKLCH for user color generation | Accepted |
+
+---
+
+When adding a new ADR, increment the number and use the format established by the existing files: **Context → Decision → Rationale → Consequences**.


### PR DESCRIPTION
Closes #22

## What's in this PR

Sets up the full documentation structure for the project.

### Files added / changed

| File | Purpose |
|------|---------|
| `README.md` | Rewritten — concise front door reflecting 1lc's intent, tech stack, project structure, and links to everything else |
| `docs/architecture.md` | System design: data model, module responsibilities, floor mechanic, hosting |
| `docs/contributing.md` | Local setup, branch conventions, PR process, code style |
| `docs/decisions/001-firebase-realtime-database.md` | ADR: why Firebase RTDB |
| `docs/decisions/002-no-framework-no-bundler.md` | ADR: why vanilla JS / no build step |
| `docs/decisions/003-oklch-color-generation.md` | ADR: why OKLCH for user color generation |

## Notes
- No code changes — docs only
- README intent is grounded in [issue #2](https://github.com/vndly/theonelinechat/issues/2)
- ADR format: context → decision → rationale → consequences