### PR TITLE
Feat/text fading

### DIFF
--- a/public/firebase.js
+++ b/public/firebase.js
@@ -42,10 +42,10 @@ export function registerUser(roomId, uid, font, color) {
 export function listenChat(callback) {
   onValue(nodeRef, (snapshot) => {
     const data = snapshot.val() || {}
-    callback({ text: data.text ?? '', color: data.color, font: data.font, activeUser: data.activeUser ?? null })
+    callback({ text: data.text ?? '', color: data.color, font: data.font, activeUser: data.activeUser ?? null, claimedAt: data.claimedAt ?? 0 })
   })
 }
 
-export function updateChat({ text, color, font, activeUser }) {
-  update(nodeRef, { text, color, font, activeUser })
+export function updateChat({ text, color, font, activeUser, claimedAt }) {
+  update(nodeRef, { text, color, font, activeUser, claimedAt })
 }

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
 <body>
   <div id="container">
     <p id="hint">press enter to create a room &nbsp;·&nbsp; type a name to join one</p>
+    <div id="display" class="hidden"></div>
     <textarea rows="1" id="input"></textarea>
   </div>
   <div id="notification" role="status" aria-live="polite"></div>

--- a/public/logic.js
+++ b/public/logic.js
@@ -303,6 +303,7 @@ async function initRoom(roomId) {
     if (text === '') {
       displayElement.innerHTML = ''
       displayElement.classList.remove('has-content')
+      resetFontSize()
       spectatorSpans = []
       spectatorText = ''
       return
@@ -388,6 +389,7 @@ async function initRoom(roomId) {
     if (floorHolder !== uid) {
       floorHolder = uid
       myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
+      floorClaimedAt = myClaimedAt
       enableInput()
       displayElement.style.color = color
       displayElement.style.fontFamily = font
@@ -407,6 +409,7 @@ async function initRoom(roomId) {
     if (!floorHolder) {
       floorHolder = uid
       myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
+      floorClaimedAt = myClaimedAt
       showCursor()
       displayElement.style.color = color
       displayElement.style.fontFamily = font
@@ -423,6 +426,11 @@ async function initRoom(roomId) {
     } else {
       // Characters removed — assume from end (backspace/delete)
       removeLastNChars(currentValue.length - newValue.length)
+      if (chars.length === 0) {
+        displayElement.classList.remove('has-content')
+        resetFontSize()
+        stopCharChecker()
+      }
     }
 
     syncTextareaToChars()

--- a/public/logic.js
+++ b/public/logic.js
@@ -180,7 +180,7 @@ async function initRoom(roomId) {
       c.el?.remove()
       c.el = null
       syncTextareaToChars()
-      broadcastText()
+      if (floorHolder === uid) broadcastText()
       if (chars.length === 0) stopCharChecker()
     }, FADE_DURATION_MS)
   }
@@ -272,11 +272,12 @@ async function initRoom(roomId) {
       floorHolder = uid
       enableInput()
       inputElement.focus()
-      showCursor()
       displayElement.style.color = color
       displayElement.style.fontFamily = font
     }
     clearAllChars()
+    displayElement.innerHTML = ''
+    showCursor()
     syncTextareaToChars()
     updateChat({ text: '', color, font, activeUser: uid })
   })

--- a/public/logic.js
+++ b/public/logic.js
@@ -42,11 +42,16 @@ function getBackgroundColor() {
   return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
 }
 
+// --- Font size constants ---
+
+const FONT_SIZE_DEFAULT = 10   // em, matches the CSS default
+const FONT_SIZE_MIN = 1        // em, smallest allowed before text becomes unreadable
+
 // --- Fading constants ---
 
-const FADE_TIMEOUT_MS = 20_000   // time before a character fades (per character, from when it was typed)
-const FADE_DURATION_MS = 2_000   // duration of the fade-out animation
-const FADE_CHAR_THRESHOLD = 120  // rolling window: oldest char fades when this limit is reached
+const FADE_TIMEOUT_MS = 10_000   // time before a character fades (per character, from when it was typed)
+const FADE_DURATION_MS = 600   // duration of the fade-out animation
+const FADE_CHAR_THRESHOLD = 200  // rolling window: oldest char fades when this limit is reached
 
 // --- Routing ---
 
@@ -126,9 +131,10 @@ async function initRoom(roomId) {
   displayElement.style.color = color
   displayElement.style.fontFamily = font
 
-  // Clicking the display focuses the hidden textarea so the floor holder can type
-  displayElement.addEventListener('click', () => {
-    if (floorHolder === uid) inputElement.focus()
+  // Prevent the browser from stealing focus or starting a text selection on the
+  // display div when clicked — the blur listener on the textarea handles re-focus.
+  displayElement.addEventListener('mousedown', event => {
+    event.preventDefault()
   })
 
   try {
@@ -147,6 +153,14 @@ async function initRoom(roomId) {
 
   let firstUpdate = true
   let floorHolder = null
+  let floorClaimedAt = 0   // timestamp of the most recent floor claim seen by this client
+  let myClaimedAt = 0      // timestamp of when this client claimed the floor
+
+  // --- Spectator display state ---
+  // Tracks spans currently in the display for non-floor-holders, including
+  // invisible ghost spans kept for layout stability when chars have faded.
+  let spectatorSpans = []
+  let spectatorText = ''
 
   // --- Per-character state (floor holder only) ---
   // Each entry: { char, addedAt, fading, el }
@@ -176,12 +190,20 @@ async function initRoom(roomId) {
     if (c.el) c.el.classList.add('fading')
     setTimeout(() => {
       const idx = chars.indexOf(c)
-      if (idx !== -1) chars.splice(idx, 1)
-      c.el?.remove()
-      c.el = null
+      if (idx === -1) return  // already cleared (e.g. Enter was pressed) — bail out
+      chars.splice(idx, 1)
+      // Keep the invisible span in the DOM so the layout doesn't shift.
+      // Only clear everything once the last char has faded.
       syncTextareaToChars()
       if (floorHolder === uid) broadcastText()
-      if (chars.length === 0) stopCharChecker()
+      if (chars.length === 0) {
+        displayElement.innerHTML = ''
+        displayElement.classList.remove('has-content')
+        resetFontSize()
+        stopCharChecker()
+      } else {
+        adjustFontSize()
+      }
     }, FADE_DURATION_MS)
   }
 
@@ -193,13 +215,12 @@ async function initRoom(roomId) {
     const c = { char: ch, addedAt: Date.now(), fading: false, el: null }
     chars.push(c)
 
-    const span = document.createElement('span')
-    span.className = 'char'
-    span.textContent = ch === ' ' ? '\u00A0' : ch
+    const span = makeCharSpan(ch)
     c.el = span
     const cursor = displayElement.querySelector('.cursor')
     cursor ? displayElement.insertBefore(span, cursor) : displayElement.appendChild(span)
-
+    displayElement.classList.add('has-content')
+    adjustFontSize()
     startCharChecker()
   }
 
@@ -217,28 +238,118 @@ async function initRoom(roomId) {
       c.el = null
     }
     chars = []
+    spectatorSpans = []
+    spectatorText = ''
+    resetFontSize()
+    displayElement.innerHTML = ''
+    displayElement.classList.remove('has-content')
     stopCharChecker()
   }
+
+  // --- Helpers ---
+
+  function makeCharSpan(ch) {
+    const span = document.createElement('span')
+    span.className = 'char'
+    span.textContent = ch === ' ' ? '\u00A0' : ch
+    return span
+  }
+
+  // --- Font size adjustment ---
+
+  let currentFontSize = FONT_SIZE_DEFAULT
+
+  function resetFontSize() {
+    currentFontSize = FONT_SIZE_DEFAULT
+    displayElement.style.fontSize = ''
+  }
+
+  function adjustFontSize() {
+    requestAnimationFrame(() => {
+      if (!displayElement.classList.contains('has-content')) return
+
+      const contentHeight = displayElement.scrollHeight
+      const windowHeight = window.innerHeight
+      if (contentHeight === 0) return
+
+      // Only shrink — never grow back until the display is fully cleared.
+      if (contentHeight <= windowHeight) return
+
+      const target = Math.max(FONT_SIZE_MIN, currentFontSize * (windowHeight / contentHeight))
+      currentFontSize = target
+      displayElement.style.fontSize = currentFontSize + 'em'
+    })
+  }
+
+  window.addEventListener('resize', adjustFontSize)
 
   function syncTextareaToChars() {
     inputElement.value = chars.map(c => c.char).join('')
   }
 
   function broadcastText() {
-    updateChat({ text: chars.map(c => c.char).join(''), color, font, activeUser: uid })
+    updateChat({ text: chars.map(c => c.char).join(''), color, font, activeUser: uid, claimedAt: myClaimedAt })
   }
 
   // --- Display helpers ---
 
-  // Renders the text as static (non-timed) spans — used for non-floor-holders
+  // Updates the display for spectators. Instead of rebuilding from scratch on
+  // every update, it diffs against the previously rendered state so that chars
+  // which have faded on the floor-holder's side are kept as invisible ghost spans
+  // here too — preventing layout shifts as the text drains away.
   function renderStaticDisplay(text) {
-    displayElement.innerHTML = ''
-    for (const ch of text) {
-      const span = document.createElement('span')
-      span.className = 'char'
-      span.textContent = ch === ' ' ? '\u00A0' : ch
-      displayElement.appendChild(span)
+    if (text === spectatorText) return
+
+    if (text === '') {
+      displayElement.innerHTML = ''
+      displayElement.classList.remove('has-content')
+      spectatorSpans = []
+      spectatorText = ''
+      return
     }
+
+    // Number of invisible ghost spans already sitting at the front of the display
+    const ghostCount = spectatorSpans.length - spectatorText.length
+
+    if (text.length < spectatorText.length) {
+      const removed = spectatorText.length - text.length
+      if (spectatorText.endsWith(text)) {
+        // Oldest chars faded — mark the corresponding spans invisible
+        for (let i = ghostCount; i < ghostCount + removed; i++) {
+          spectatorSpans[i].classList.add('fading')
+        }
+        spectatorText = text
+        return
+      }
+      if (spectatorText.startsWith(text)) {
+        // Chars deleted from the end (backspace) — remove those spans immediately
+        const removed = spectatorSpans.splice(ghostCount + text.length)
+        for (const span of removed) span.remove()
+        spectatorText = text
+        return
+      }
+    } else if (text.startsWith(spectatorText)) {
+      // Chars added at the end
+      for (const ch of text.slice(spectatorText.length)) {
+        const span = makeCharSpan(ch)
+        displayElement.appendChild(span)
+        spectatorSpans.push(span)
+      }
+      displayElement.classList.add('has-content')
+      spectatorText = text
+      return
+    }
+
+    // Full rebuild — floor holder changed or unrecognised delta
+    displayElement.innerHTML = ''
+    spectatorSpans = []
+    displayElement.classList.toggle('has-content', text.length > 0)
+    for (const ch of text) {
+      const span = makeCharSpan(ch)
+      displayElement.appendChild(span)
+      spectatorSpans.push(span)
+    }
+    spectatorText = text
   }
 
   function showCursor() {
@@ -264,22 +375,29 @@ async function initRoom(roomId) {
     inputElement.blur()
   }
 
+  // Keep the hidden textarea focused whenever this user holds the floor.
+  // Handles any browser quirk that causes it to lose focus unexpectedly.
+  inputElement.addEventListener('blur', () => {
+    if (floorHolder === uid) requestAnimationFrame(() => inputElement.focus())
+  })
+
   // Global Enter listener — works without clicking the display
   document.addEventListener('keydown', function (event) {
     if (event.key !== 'Enter') return
     event.preventDefault()
     if (floorHolder !== uid) {
       floorHolder = uid
+      myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
       enableInput()
-      inputElement.focus()
       displayElement.style.color = color
       displayElement.style.fontFamily = font
     }
+    inputElement.focus()
     clearAllChars()
     displayElement.innerHTML = ''
     showCursor()
     syncTextareaToChars()
-    updateChat({ text: '', color, font, activeUser: uid })
+    updateChat({ text: '', color, font, activeUser: uid, claimedAt: myClaimedAt })
   })
 
   listenChat(updateInput)
@@ -288,6 +406,7 @@ async function initRoom(roomId) {
     // Auto-claim floor on first keystroke if unclaimed
     if (!floorHolder) {
       floorHolder = uid
+      myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
       showCursor()
       displayElement.style.color = color
       displayElement.style.fontFamily = font
@@ -310,8 +429,12 @@ async function initRoom(roomId) {
     broadcastText()
   })
 
-  function updateInput({ text, color: textColor, font: textFont, activeUser }) {
+  function updateInput({ text, color: textColor, font: textFont, activeUser, claimedAt = 0 }) {
+    if (claimedAt < floorClaimedAt) return  // stale broadcast from a previous floor holder
+    floorClaimedAt = claimedAt
+
     const wasHolder = floorHolder === uid
+    const previousHolder = floorHolder
     floorHolder = activeUser
     const iAmHolder = floorHolder === uid
     const floorTaken = floorHolder !== null
@@ -329,7 +452,13 @@ async function initRoom(roomId) {
       enableInput()
       showCursor()
     } else {
+      if (floorHolder !== previousHolder) {
+        spectatorSpans = []
+        spectatorText = ''
+        resetFontSize()
+      }
       renderStaticDisplay(text)
+      adjustFontSize()
       hideCursor()
       if (floorTaken) {
         disableInput()

--- a/public/logic.js
+++ b/public/logic.js
@@ -42,12 +42,17 @@ function getBackgroundColor() {
   return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
 }
 
-const MAX_INPUT_LENGTH = 100
+// --- Fading constants ---
+
+const FADE_TIMEOUT_MS = 20_000   // time before a character fades (per character, from when it was typed)
+const FADE_DURATION_MS = 2_000   // duration of the fade-out animation
+const FADE_CHAR_THRESHOLD = 120  // rolling window: oldest char fades when this limit is reached
 
 // --- Routing ---
 
 const roomId = sanitiseRoomId(window.location.pathname.slice(1))
 const inputElement = document.getElementById('input')
+const displayElement = document.getElementById('display')
 const hintElement = document.getElementById('hint')
 const notificationElement = document.getElementById('notification')
 const overlayElement = document.getElementById('overlay')
@@ -115,6 +120,17 @@ async function initRoom(roomId) {
   setRoom(roomId)
   hintElement.classList.add('hidden')
 
+  // Switch to display mode: hide textarea off-screen, show display div
+  inputElement.classList.add('room-hidden')
+  displayElement.classList.remove('hidden')
+  displayElement.style.color = color
+  displayElement.style.fontFamily = font
+
+  // Clicking the display focuses the hidden textarea so the floor holder can type
+  displayElement.addEventListener('click', () => {
+    if (floorHolder === uid) inputElement.focus()
+  })
+
   try {
     const takenFonts = await getTakenFonts(roomId, uid)
     if (takenFonts.includes(font)) {
@@ -132,7 +148,123 @@ async function initRoom(roomId) {
   let firstUpdate = true
   let floorHolder = null
 
-  // Global Enter listener — works without clicking the input
+  // --- Per-character state (floor holder only) ---
+  // Each entry: { char, addedAt, fading, el }
+  let chars = []
+  let charCheckInterval = null
+
+  function startCharChecker() {
+    if (charCheckInterval) return
+    charCheckInterval = setInterval(checkExpiredChars, 200)
+  }
+
+  function stopCharChecker() {
+    clearInterval(charCheckInterval)
+    charCheckInterval = null
+  }
+
+  function checkExpiredChars() {
+    const now = Date.now()
+    for (const c of chars) {
+      if (!c.fading && now - c.addedAt >= FADE_TIMEOUT_MS) startCharFade(c)
+    }
+  }
+
+  function startCharFade(c) {
+    if (c.fading) return
+    c.fading = true
+    if (c.el) c.el.classList.add('fading')
+    setTimeout(() => {
+      const idx = chars.indexOf(c)
+      if (idx !== -1) chars.splice(idx, 1)
+      c.el?.remove()
+      c.el = null
+      syncTextareaToChars()
+      broadcastText()
+      if (chars.length === 0) stopCharChecker()
+    }, FADE_DURATION_MS)
+  }
+
+  function addChar(ch) {
+    // When the rolling window is full, start fading the oldest active character
+    const active = chars.filter(c => !c.fading)
+    if (active.length >= FADE_CHAR_THRESHOLD) startCharFade(active[0])
+
+    const c = { char: ch, addedAt: Date.now(), fading: false, el: null }
+    chars.push(c)
+
+    const span = document.createElement('span')
+    span.className = 'char'
+    span.textContent = ch === ' ' ? '\u00A0' : ch
+    c.el = span
+    const cursor = displayElement.querySelector('.cursor')
+    cursor ? displayElement.insertBefore(span, cursor) : displayElement.appendChild(span)
+
+    startCharChecker()
+  }
+
+  function removeLastNChars(n) {
+    const removed = chars.splice(chars.length - n, n)
+    for (const c of removed) {
+      c.el?.remove()
+      c.el = null
+    }
+  }
+
+  function clearAllChars() {
+    for (const c of chars) {
+      c.el?.remove()
+      c.el = null
+    }
+    chars = []
+    stopCharChecker()
+  }
+
+  function syncTextareaToChars() {
+    inputElement.value = chars.map(c => c.char).join('')
+  }
+
+  function broadcastText() {
+    updateChat({ text: chars.map(c => c.char).join(''), color, font, activeUser: uid })
+  }
+
+  // --- Display helpers ---
+
+  // Renders the text as static (non-timed) spans — used for non-floor-holders
+  function renderStaticDisplay(text) {
+    displayElement.innerHTML = ''
+    for (const ch of text) {
+      const span = document.createElement('span')
+      span.className = 'char'
+      span.textContent = ch === ' ' ? '\u00A0' : ch
+      displayElement.appendChild(span)
+    }
+  }
+
+  function showCursor() {
+    if (!displayElement.querySelector('.cursor')) {
+      const cursor = document.createElement('span')
+      cursor.className = 'cursor'
+      displayElement.appendChild(cursor)
+    }
+  }
+
+  function hideCursor() {
+    displayElement.querySelector('.cursor')?.remove()
+  }
+
+  // --- Floor management ---
+
+  function enableInput() {
+    inputElement.removeAttribute('tabindex')
+  }
+
+  function disableInput() {
+    inputElement.setAttribute('tabindex', '-1')
+    inputElement.blur()
+  }
+
+  // Global Enter listener — works without clicking the display
   document.addEventListener('keydown', function (event) {
     if (event.key !== 'Enter') return
     event.preventDefault()
@@ -140,60 +272,77 @@ async function initRoom(roomId) {
       floorHolder = uid
       enableInput()
       inputElement.focus()
+      showCursor()
+      displayElement.style.color = color
+      displayElement.style.fontFamily = font
     }
+    clearAllChars()
+    syncTextareaToChars()
     updateChat({ text: '', color, font, activeUser: uid })
   })
 
   listenChat(updateInput)
 
   inputElement.addEventListener('input', event => {
-    const target = event.target
-    if (target.value.length > MAX_INPUT_LENGTH) {
-      target.value = target.value.slice(0, MAX_INPUT_LENGTH)
+    // Auto-claim floor on first keystroke if unclaimed
+    if (!floorHolder) {
+      floorHolder = uid
+      showCursor()
+      displayElement.style.color = color
+      displayElement.style.fontFamily = font
     }
-    updateHeight(target)
-    // Claims floor on first edit if unclaimed; broadcasts live text updates
-    if (!floorHolder) floorHolder = uid
-    if (floorHolder === uid) {
-      updateChat({ text: target.value, color, font, activeUser: uid })
+    if (floorHolder !== uid) return
+
+    const newValue = event.target.value
+    const currentValue = chars.map(c => c.char).join('')
+    if (newValue === currentValue) return
+
+    if (newValue.length > currentValue.length) {
+      // Characters added — assume at end (no mid-text cursor repositioning)
+      for (const ch of newValue.slice(currentValue.length)) addChar(ch)
+    } else {
+      // Characters removed — assume from end (backspace/delete)
+      removeLastNChars(currentValue.length - newValue.length)
     }
+
+    syncTextareaToChars()
+    broadcastText()
   })
 
-  function enableInput() {
-    inputElement.style.pointerEvents = ''
-    inputElement.removeAttribute('tabindex')
-  }
-
-  function disableInput() {
-    inputElement.style.pointerEvents = 'none'
-    inputElement.setAttribute('tabindex', '-1')
-    inputElement.blur()
-  }
-
   function updateInput({ text, color: textColor, font: textFont, activeUser }) {
-    inputElement.value = text
-    inputElement.style.color = textColor || color
-    inputElement.style.fontFamily = textFont || font
-    updateHeight(inputElement)
-
+    const wasHolder = floorHolder === uid
     floorHolder = activeUser
     const iAmHolder = floorHolder === uid
     const floorTaken = floorHolder !== null
 
-    if (floorTaken && !iAmHolder) {
-      disableInput()
-    } else {
+    displayElement.style.color = textColor || color
+    displayElement.style.fontFamily = textFont || font
+
+    if (wasHolder && !iAmHolder) {
+      // Lost the floor — clean up local char state
+      clearAllChars()
+    }
+
+    if (iAmHolder) {
+      // Own update echoing back — chars array is source of truth, don't re-render
       enableInput()
+      showCursor()
+    } else {
+      renderStaticDisplay(text)
+      hideCursor()
+      if (floorTaken) {
+        disableInput()
+      } else {
+        enableInput()
+      }
     }
 
     if (firstUpdate) {
       firstUpdate = false
-      if (!text && !floorTaken) inputElement.focus()
+      if (!text && !floorTaken) {
+        enableInput()
+        inputElement.focus()
+      }
     }
   }
-}
-
-function updateHeight(el) {
-  el.style.height = 'auto'
-  el.style.height = `${el.scrollHeight}px`
 }

--- a/public/style.css
+++ b/public/style.css
@@ -57,18 +57,29 @@ body {
   word-break: break-word;
   line-height: 1.2;
   cursor: text;
+  user-select: none;
+}
+
+#display.has-content {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  right: 0;
+  width: auto;
+  transform: translateY(-50%);
 }
 
 #display.hidden {
   display: none;
 }
 
-#display .char {
-  transition: opacity 2s ease;
+#display .char.fading {
+  animation: char-fade 0.6s ease-out forwards;
 }
 
-#display .char.fading {
-  opacity: 0;
+@keyframes char-fade {
+  from { opacity: 1; }
+  to   { opacity: 0; }
 }
 
 #display .cursor {

--- a/public/style.css
+++ b/public/style.css
@@ -40,6 +40,52 @@ body {
   overflow: hidden;
 }
 
+/* In room mode the textarea moves off-screen; #display takes over visually */
+#input.room-hidden {
+  position: fixed;
+  top: -9999px;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+#display {
+  width: 100%;
+  font-size: 10em;
+  text-align: center;
+  word-break: break-word;
+  line-height: 1.2;
+  cursor: text;
+}
+
+#display.hidden {
+  display: none;
+}
+
+#display .char {
+  transition: opacity 2s ease;
+}
+
+#display .char.fading {
+  opacity: 0;
+}
+
+#display .cursor {
+  display: inline-block;
+  width: 0.05em;
+  height: 0.85em;
+  background: currentColor;
+  vertical-align: text-bottom;
+  margin-left: 0.02em;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
 #overlay {
   display: none;
   position: fixed;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -6,6 +6,7 @@ import {
   generateRoomId,
   getRelativeLuminance,
   oklchToHex,
+  findOKLCHLightness,
   generateReadableColor,
   contrastRatio,
 } from '../public/utils.js'
@@ -181,4 +182,77 @@ describe('generateReadableColor', () => {
       }
     })
   }
+})
+
+// --- contrastRatio ---
+
+describe('contrastRatio', () => {
+  it('returns ~21 for black on white', () => {
+    assert.ok(Math.abs(contrastRatio('#000000', '#ffffff') - 21) < 0.1)
+  })
+
+  it('is symmetric — order of arguments does not matter', () => {
+    const a = contrastRatio('#0882bb', '#ffffff')
+    const b = contrastRatio('#ffffff', '#0882bb')
+    assert.ok(Math.abs(a - b) < 0.0001)
+  })
+
+  it('returns exactly 1 for the same color against itself', () => {
+    assert.equal(contrastRatio('#0882bb', '#0882bb'), 1)
+  })
+
+  it('always returns a value >= 1', () => {
+    const pairs = [
+      ['#000000', '#ffffff'],
+      ['#ff0000', '#00ff00'],
+      ['#0882bb', '#123456'],
+      ['#abcdef', '#fedcba'],
+    ]
+    for (const [a, b] of pairs) {
+      assert.ok(contrastRatio(a, b) >= 1, `contrastRatio(${a}, ${b}) < 1`)
+    }
+  })
+})
+
+// --- findOKLCHLightness ---
+
+describe('findOKLCHLightness', () => {
+  it('returns a value in [0, 1]', () => {
+    const L = findOKLCHLightness(0, 0, 0.2)
+    assert.ok(L >= 0 && L <= 1)
+  })
+
+  it('achromatic: produced color has luminance close to target', () => {
+    // C=0 makes the OKLCH→sRGB mapping monotone, so binary search is exact
+    const targets = [0.05, 0.2, 0.5, 0.8]
+    for (const target of targets) {
+      const L = findOKLCHLightness(0, 0, target)
+      const actual = getRelativeLuminance(oklchToHex(L, 0, 0))
+      assert.ok(Math.abs(actual - target) < 0.005, `target ${target}, got ${actual}`)
+    }
+  })
+
+  it('higher target luminance produces higher lightness (achromatic)', () => {
+    const L1 = findOKLCHLightness(0, 0, 0.1)
+    const L2 = findOKLCHLightness(0, 0, 0.5)
+    const L3 = findOKLCHLightness(0, 0, 0.9)
+    assert.ok(L1 < L2 && L2 < L3)
+  })
+
+  it('targetLuminance=0 produces near-black', () => {
+    const L = findOKLCHLightness(0, 0, 0)
+    assert.ok(getRelativeLuminance(oklchToHex(L, 0, 0)) < 0.01)
+  })
+
+  it('targetLuminance=1 produces near-white (achromatic)', () => {
+    const L = findOKLCHLightness(0, 0, 1)
+    assert.ok(getRelativeLuminance(oklchToHex(L, 0, 0)) > 0.98)
+  })
+
+  it('works with non-zero chroma and returns a value in [0, 1]', () => {
+    for (const hue of [0, 90, 180, 270]) {
+      const L = findOKLCHLightness(0.15, hue, 0.4)
+      assert.ok(L >= 0 && L <= 1, `hue ${hue}: L=${L} out of range`)
+    }
+  })
 })


### PR DESCRIPTION
  What's in this PR                                                                                                                                  
                                                                                                                                                     
  - Per-character fading — each character fades out individually based on when it was typed (10s timeout, 0.6s ease-out animation), rather than      
  clearing all at once                                                                                                                               
  - Layout stability during fading — faded characters stay in the DOM as invisible ghost spans so the text doesn't jump as it drains away; this
  applies to both the floor holder and spectators
  - Spectator sync — spectator rendering now diffs against the previous state instead of rebuilding from scratch, so ghost spans are mirrored
  correctly on the spectator side too
  - Dynamic font scaling — text shrinks automatically when it overflows the viewport height, and resets when the display clears
  - Vertical centering fix — text stays centred throughout the fading process via a has-content fixed-position class
  - Lamport floor claims — floor broadcasts now carry a claimedAt timestamp; stale fade-timeout writes are ignored if a newer floor claim has been
  seen, preventing fading text from reappearing after a floor handoff
  - Firefox focus fix — replaced click handler with mousedown + blur re-focus listener to keep the hidden textarea focused in all browsers
  - Tests — added dedicated tests for contrastRatio and findOKLCHLightness