### PR TITLE
fix: enable typing on mobile (hidden textarea focus)

### DIFF
--- a/public/logic.js
+++ b/public/logic.js
@@ -137,6 +137,11 @@ async function initRoom(roomId) {
     event.preventDefault()
   })
 
+  let firstUpdate = true
+  let floorHolder = null
+  let floorClaimedAt = 0   // timestamp of the most recent floor claim seen by this client
+  let myClaimedAt = 0      // timestamp of when this client claimed the floor
+
   // Mobile: claim the floor and focus the textarea synchronously inside the
   // touchstart gesture handler. Programmatic focus() is only honoured on mobile
   // browsers when called directly within a user-gesture callback (not inside
@@ -159,11 +164,6 @@ async function initRoom(roomId) {
     // keep current font on network/permission error
   }
   registerUser(roomId, uid, font, color)
-
-  let firstUpdate = true
-  let floorHolder = null
-  let floorClaimedAt = 0   // timestamp of the most recent floor claim seen by this client
-  let myClaimedAt = 0      // timestamp of when this client claimed the floor
 
   // --- Spectator display state ---
   // Tracks spans currently in the display for non-floor-holders, including

--- a/public/logic.js
+++ b/public/logic.js
@@ -137,6 +137,28 @@ async function initRoom(roomId) {
     event.preventDefault()
   })
 
+  // Mobile: claim the floor and focus the textarea synchronously inside the
+  // touchstart gesture handler. Programmatic focus() is only honoured on mobile
+  // browsers when called directly within a user-gesture callback (not inside
+  // requestAnimationFrame, setTimeout, or after an async round-trip).
+  displayElement.addEventListener('touchstart', event => {
+    event.preventDefault()
+    if (floorHolder !== uid) {
+      floorHolder = uid
+      myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
+      floorClaimedAt = myClaimedAt
+      enableInput()
+      displayElement.style.color = color
+      displayElement.style.fontFamily = font
+    }
+    inputElement.focus()
+    clearAllChars()
+    displayElement.innerHTML = ''
+    showCursor()
+    syncTextareaToChars()
+    updateChat({ text: '', color, font, activeUser: uid, claimedAt: myClaimedAt })
+  })
+
   try {
     const takenFonts = await getTakenFonts(roomId, uid)
     if (takenFonts.includes(font)) {
@@ -379,7 +401,7 @@ async function initRoom(roomId) {
   // Keep the hidden textarea focused whenever this user holds the floor.
   // Handles any browser quirk that causes it to lose focus unexpectedly.
   inputElement.addEventListener('blur', () => {
-    if (floorHolder === uid) requestAnimationFrame(() => inputElement.focus())
+    if (floorHolder === uid) inputElement.focus()
   })
 
   // Global Enter listener — works without clicking the display

--- a/public/logic.js
+++ b/public/logic.js
@@ -143,20 +143,7 @@ async function initRoom(roomId) {
   // requestAnimationFrame, setTimeout, or after an async round-trip).
   displayElement.addEventListener('touchstart', event => {
     event.preventDefault()
-    if (floorHolder !== uid) {
-      floorHolder = uid
-      myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
-      floorClaimedAt = myClaimedAt
-      enableInput()
-      displayElement.style.color = color
-      displayElement.style.fontFamily = font
-    }
-    inputElement.focus()
-    clearAllChars()
-    displayElement.innerHTML = ''
-    showCursor()
-    syncTextareaToChars()
-    updateChat({ text: '', color, font, activeUser: uid, claimedAt: myClaimedAt })
+    claimFloorAndStart()
   })
 
   try {
@@ -398,16 +385,9 @@ async function initRoom(roomId) {
     inputElement.blur()
   }
 
-  // Keep the hidden textarea focused whenever this user holds the floor.
-  // Handles any browser quirk that causes it to lose focus unexpectedly.
-  inputElement.addEventListener('blur', () => {
-    if (floorHolder === uid) inputElement.focus()
-  })
-
-  // Global Enter listener — works without clicking the display
-  document.addEventListener('keydown', function (event) {
-    if (event.key !== 'Enter') return
-    event.preventDefault()
+  // Claim the floor (if not already held) and reset the display to a blank
+  // slate ready for input. Called on Enter (desktop) and touchstart (mobile).
+  function claimFloorAndStart() {
     if (floorHolder !== uid) {
       floorHolder = uid
       myClaimedAt = Math.max(Date.now(), floorClaimedAt + 1)
@@ -422,6 +402,19 @@ async function initRoom(roomId) {
     showCursor()
     syncTextareaToChars()
     updateChat({ text: '', color, font, activeUser: uid, claimedAt: myClaimedAt })
+  }
+
+  // Keep the hidden textarea focused whenever this user holds the floor.
+  // Handles any browser quirk that causes it to lose focus unexpectedly.
+  inputElement.addEventListener('blur', () => {
+    if (floorHolder === uid) requestAnimationFrame(() => inputElement.focus())
+  })
+
+  // Global Enter listener — works without clicking the display
+  document.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter') return
+    event.preventDefault()
+    claimFloorAndStart()
   })
 
   listenChat(updateInput)


### PR DESCRIPTION
## Summary

- Adds a `touchstart` handler on the display element that calls `inputElement.focus()` synchronously within the gesture callback — mobile browsers silently ignore `focus()` calls made outside a direct user-gesture handler (e.g. inside `requestAnimationFrame` or after a Firebase round-trip)
- Extracts `claimFloorAndStart()` to eliminate the duplicated floor-claim + display-reset logic that the new touch handler and the existing Enter keydown handler both needed

## What was not changed

The `requestAnimationFrame` wrapper on the blur re-focus listener is intentionally kept — it was there to handle desktop browser quirks and the `touchstart` handler is sufficient for mobile on its own.

Fixes #27

## Test plan

- [ ] Open a room on iOS Safari — tap the screen, virtual keyboard should appear and typing should work
- [ ] Open a room on Android Chrome — same check
- [ ] Open a room on desktop — Enter key still claims the floor and focuses the textarea as before
- [ ] Two users: verify one user tapping on mobile correctly steals the floor from the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)